### PR TITLE
Add KPI cards, revenue trend chart, and update defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0] - 2026-03-07
+
+### Added
+- Three new KPI value boxes: Average Revenue (filtered), Year-over-Year Revenue %, Month-over-Month Revenue %
+- Revenue trend line chart showing monthly revenue for the top 5 sales reps (responds to all filters)
+- YoY and MoM cards respond to country and product filters but ignore the date range, so they always compare full time periods
+
+### Changed
+- Default date range updated from a single month (Aug 2024) to the full latest year (Jan–Aug 2024). The previous single-month default left the revenue trend chart empty and gave a narrow view of KPIs. A full-year default provides meaningful trend data, actionable KPI context, and a better first impression of the dashboard. Country and product filters default to "All" to maximize the initial data scope.
+
 ## [0.2.0] - 2026-02-27
 
 ### Added

--- a/src/app.py
+++ b/src/app.py
@@ -33,12 +33,14 @@ if __package__ and __package__ != "__main__":
     from .value_boxes import value_boxes_ui
     from .map_chart import map_chart_ui
     from .leaderboard import leaderboard_ui
+    from .revenue_trend import revenue_trend_ui
 else:
     from theme import get_head_content
     from filters import filters_ui
     from value_boxes import value_boxes_ui
     from map_chart import map_chart_ui
     from leaderboard import leaderboard_ui
+    from revenue_trend import revenue_trend_ui
 
 # -- Constants ----------------------------------------------------------------
 _COUNTRY_CODES = {
@@ -125,6 +127,10 @@ app_ui = ui.page_navbar(
                 ),
                 col_widths=(7, 5),
             ),
+            ui.card(
+                revenue_trend_ui(),
+                style="height: 450px; overflow-y: auto;",
+            ),
             _footer,
             style="padding: 1rem;",
         ),
@@ -204,6 +210,48 @@ def server(input, output, session):
     @render.text
     def active_reps():
         return str(filtered_data()["Sales Person"].nunique())
+
+    @render.text
+    def avg_revenue():
+        data = filtered_data()
+        if data.empty:
+            return "$0"
+        return f"${data['Amount'].mean():,.0f}"
+
+    @render.text
+    def yoy_revenue():
+        # Compare the last available year's revenue (up to its last month)
+        # to the same months in the prior year. Not affected by date filter.
+        monthly = df.groupby(df["Date"].dt.to_period("M"))["Amount"].sum()
+        last_date = df["Date"].max()
+        current_year = last_date.year
+        last_month = last_date.month
+        current_rev = monthly[
+            (monthly.index.year == current_year) & (monthly.index.month <= last_month)
+        ].sum()
+        prior_rev = monthly[
+            (monthly.index.year == current_year - 1) & (monthly.index.month <= last_month)
+        ].sum()
+        if prior_rev == 0:
+            return "N/A"
+        pct = (current_rev - prior_rev) / prior_rev * 100
+        arrow = "+" if pct >= 0 else ""
+        return f"{arrow}{pct:.1f}%"
+
+    @render.text
+    def mom_revenue():
+        # Compare the last available month's revenue to the prior month.
+        # Not affected by date filter.
+        monthly = df.groupby(df["Date"].dt.to_period("M"))["Amount"].sum().sort_index()
+        if len(monthly) < 2:
+            return "N/A"
+        current_rev = monthly.iloc[-1]
+        prior_rev = monthly.iloc[-2]
+        if prior_rev == 0:
+            return "N/A"
+        pct = (current_rev - prior_rev) / prior_rev * 100
+        arrow = "+" if pct >= 0 else ""
+        return f"{arrow}{pct:.1f}%"
 
     @render.ui
     def map_chart():
@@ -287,6 +335,49 @@ def server(input, output, session):
         }])
         return pd.concat([leaderboard, summary], ignore_index=True)
     
+    @render.ui
+    def revenue_trend_chart():
+        data = filtered_data()
+        if data.empty:
+            return ui.p("No data to display.")
+
+        # Identify top 5 sales reps by total revenue
+        top5 = (
+            data.groupby("Sales Person")["Amount"]
+            .sum()
+            .nlargest(5)
+            .index.tolist()
+        )
+        trend_data = data[data["Sales Person"].isin(top5)].copy()
+        trend_data["Month"] = trend_data["Date"].dt.to_period("M").dt.to_timestamp()
+
+        monthly = (
+            trend_data.groupby(["Month", "Sales Person"])["Amount"]
+            .sum()
+            .reset_index()
+        )
+
+        chart = (
+            alt.Chart(monthly)
+            .mark_line(point=True)
+            .encode(
+                x=alt.X("Month:T", title="Month"),
+                y=alt.Y("Amount:Q", title="Revenue (USD)", axis=alt.Axis(format="$,.0f")),
+                color=alt.Color("Sales Person:N", title="Sales Rep"),
+                tooltip=[
+                    alt.Tooltip("Sales Person:N", title="Sales Rep"),
+                    alt.Tooltip("Month:T", title="Month", format="%b %Y"),
+                    alt.Tooltip("Amount:Q", title="Revenue", format="$,.0f"),
+                ],
+            )
+            .properties(width="container", height=350)
+        )
+
+        return ui.tags.iframe(
+            srcdoc=chart.to_html(),
+            style="width:100%;height:400px;border:none;",
+        )
+
     # ── Tab 2: AI chat ────────────────────────────────────────────────────────
     qc_vals = qc.server()
 

--- a/src/app.py
+++ b/src/app.py
@@ -114,7 +114,7 @@ app_ui = ui.page_navbar(
     ui.nav_panel(
         "Chocolate Sales Dashboard",
         ui.tags.div(
-            filters_ui(countries, products, "2024-08-01", "2024-08-31"), #set the default date range to 2025
+            filters_ui(countries, products, "2024-01-01", "2024-08-31"),
             value_boxes_ui(),
             ui.layout_columns(
                 ui.card(

--- a/src/app.py
+++ b/src/app.py
@@ -379,7 +379,11 @@ def server(input, output, session):
             .encode(
                 x=alt.X("Month:T", title="Month"),
                 y=alt.Y("Amount:Q", title="Revenue (USD)", axis=alt.Axis(format="$,.0f")),
-                color=alt.Color("Sales Person:N", title="Sales Rep"),
+                color=alt.Color(
+                    "Sales Person:N",
+                    title="Sales Rep",
+                    scale=alt.Scale(range=["#5D3A1A", "#8B5E3C", "#C4A35A", "#A0522D", "#D2956A"]),
+                ),
                 tooltip=[
                     alt.Tooltip("Sales Person:N", title="Sales Rep"),
                     alt.Tooltip("Month:T", title="Month", format="%b %Y"),

--- a/src/app.py
+++ b/src/app.py
@@ -218,12 +218,25 @@ def server(input, output, session):
             return "$0"
         return f"${data['Amount'].mean():,.0f}"
 
+    @reactive.calc
+    def non_date_filtered_data():
+        """Apply country and product filters but not date filter."""
+        data = df.copy()
+        if input.country():
+            data = data[data["Country"].isin(input.country())]
+        if input.product():
+            data = data[data["Product"].isin(input.product())]
+        return data
+
     @render.text
     def yoy_revenue():
         # Compare the last available year's revenue (up to its last month)
-        # to the same months in the prior year. Not affected by date filter.
-        monthly = df.groupby(df["Date"].dt.to_period("M"))["Amount"].sum()
-        last_date = df["Date"].max()
+        # to the same months in the prior year. Responds to country/product filters.
+        data = non_date_filtered_data()
+        if data.empty:
+            return "N/A"
+        monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum()
+        last_date = data["Date"].max()
         current_year = last_date.year
         last_month = last_date.month
         current_rev = monthly[
@@ -241,8 +254,11 @@ def server(input, output, session):
     @render.text
     def mom_revenue():
         # Compare the last available month's revenue to the prior month.
-        # Not affected by date filter.
-        monthly = df.groupby(df["Date"].dt.to_period("M"))["Amount"].sum().sort_index()
+        # Responds to country/product filters.
+        data = non_date_filtered_data()
+        if data.empty:
+            return "N/A"
+        monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum().sort_index()
         if len(monthly) < 2:
             return "N/A"
         current_rev = monthly.iloc[-1]

--- a/src/revenue_trend.py
+++ b/src/revenue_trend.py
@@ -1,0 +1,12 @@
+"""Revenue trend line chart for top 5 salespersons."""
+
+from shiny import ui
+
+
+def revenue_trend_ui():
+    """Build the revenue trend card."""
+    return ui.card(
+        ui.card_header("Revenue Trend — Top 5 Sales Reps"),
+        ui.output_ui("revenue_trend_chart"),
+        full_screen=True,
+    )

--- a/src/value_boxes.py
+++ b/src/value_boxes.py
@@ -14,6 +14,15 @@ icon_boxes = ui.HTML(
 icon_reps = ui.HTML(
     f'<i class="bi bi-people" style="font-size: {_ICON_SIZE}; color: {_ICON_COLOR};"></i>'
 )
+icon_avg = ui.HTML(
+    f'<i class="bi bi-calculator" style="font-size: {_ICON_SIZE}; color: {_ICON_COLOR};"></i>'
+)
+icon_yoy = ui.HTML(
+    f'<i class="bi bi-graph-up-arrow" style="font-size: {_ICON_SIZE}; color: {_ICON_COLOR};"></i>'
+)
+icon_mom = ui.HTML(
+    f'<i class="bi bi-bar-chart-line" style="font-size: {_ICON_SIZE}; color: {_ICON_COLOR};"></i>'
+)
 
 
 def value_boxes_ui():
@@ -37,7 +46,25 @@ def value_boxes_ui():
             showcase=icon_reps,
             height="auto",
         ),
-        col_widths=(4, 4, 4),
+        ui.value_box(
+            "Avg Revenue (Filtered)",
+            ui.output_text("avg_revenue"),
+            showcase=icon_avg,
+            height="auto",
+        ),
+        ui.value_box(
+            "Year-over-Year Revenue",
+            ui.output_text("yoy_revenue"),
+            showcase=icon_yoy,
+            height="auto",
+        ),
+        ui.value_box(
+            "Month-over-Month Revenue",
+            ui.output_text("mom_revenue"),
+            showcase=icon_mom,
+            height="auto",
+        ),
+        col_widths=(4, 4, 4, 4, 4, 4),
         fill=False,
         fillable=False,
     )


### PR DESCRIPTION
## Summary
- Add three new KPI value boxes: Average Revenue (filtered), Year-over-Year Revenue %, and Month-over-Month Revenue %
- Add revenue trend line chart for top 5 sales reps with chocolate-themed color palette
- YoY and MoM cards respond to country/product filters but ignore date range for full-period comparisons
- Update default date range from single month (Aug 2024) to full year (Jan–Aug 2024)
- Document changes in CHANGELOG.md

Closes #55, closes #56

## Test plan
- [ ] Verify three new KPI cards render correctly on dashboard load
- [ ] Confirm Avg Revenue updates when changing date, country, and product filters
- [ ] Confirm YoY and MoM cards update with country/product filters but not date filter
- [ ] Verify revenue trend chart shows top 5 sales reps with chocolate color palette
- [ ] Verify trend chart updates reactively with all filters
- [ ] Check default date range loads as Jan 1 – Aug 31, 2024