### PR TITLE
M4 enhancements: map click-to-filter, candy palette, layout fixes, DuckDB/Parquet migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ The dashboard uses the **Chocolate Sales** dataset from Kaggle:
    shiny run src/app.py --reload
    ```
 
+## Running Tests
+
+First-time setup (install browser for Playwright):
+
+```bash
+playwright install chromium
+```
+
+Then run all tests with:
+
+```bash
+pytest
+```
+
+The Playwright tests start the Shiny app automatically — no need to run it manually.
+
+### What the tests cover
+
+| Test | File | What it verifies | What breaks if it fails |
+|------|------|-----------------|------------------------|
+| `test_leaderboard_empty_returns_correct_schema` | unit | Empty DataFrame returns correct column headers | DataGrid component would crash on schema mismatch |
+| `test_leaderboard_ranks_by_revenue_descending` | unit | Reps are sorted by revenue descending, rank 1 = highest earner | Sort bug would silently flip the leaderboard |
+| `test_leaderboard_summary_row_shows_totals` | unit | Last row is "AVERAGE / TOTAL" with correct revenue and 100% share | Missing footer row would break leaderboard display |
+| `test_leaderboard_rev_shares_sum_to_100` | unit | Individual rev shares add up to 100% | Division/rounding error would cause inconsistent totals |
+| `test_inject_click_handler_inserts_js_block` | unit | postMessage JS is injected before the Vega IIFE | Map clicks would not propagate country names to Shiny |
+| `test_inject_click_handler_preserves_iife_marker` | unit | IIFE marker stays in output after injection | Vega chart would fail to render |
+| `test_inject_click_handler_noop_on_missing_marker` | unit | HTML without the marker is unchanged | Arbitrary HTML could be corrupted |
+| `test_compute_yoy_revenue_*` (3 tests) | unit | YoY returns correct % or N/A for empty/single-year data | Wrong formula or divide-by-zero in the KPI box |
+| `test_compute_mom_revenue_*` (3 tests) | unit | MoM returns correct % or N/A for empty/single-month data | Wrong indexing or divide-by-zero in the KPI box |
+| `test_dashboard_renders_all_sections` | playwright | All main UI sections visible on load | A component mount failure goes undetected |
+| `test_total_revenue_kpi_displays_dollar_amount` | playwright | Revenue KPI shows a `$`-formatted value | Broken reactive pipeline would leave the field blank |
+| `test_country_filter_keeps_leaderboard_visible` | playwright | Applying a country filter doesn't crash the leaderboard | Broken filter reactive would clear the output |
+| `test_out_of_range_date_shows_no_data_message` | playwright | Future date range shows "No data to display." | Missing empty-state guard would raise an unhandled exception |
+
 ## Contributors
 
 - [Daisy Zhou](https://github.com/daisyzhou-ubc)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,10 @@ chatlas==0.15.2
 python-dotenv==1.2.2
 anthropic==0.84.0
 ibis-framework==12.0.0
-duckdb==1.5.0 
+duckdb==1.5.0
+
+# Testing
+pytest>=8.0
+pytest-playwright>=0.5.0
+playwright>=1.40
 

--- a/src/app.py
+++ b/src/app.py
@@ -178,7 +178,7 @@ def server(input, output, session):
     def map_chart():
         selected = list(input.country()) if input.country() else None
         return country_choropleth_ui(
-            map_data(), COUNTRY_CODES, WORLD_TOPO_URL, 320, "350px",
+            map_data(), COUNTRY_CODES, WORLD_TOPO_URL, 340, "370px",
             clickable=True, selected_countries=selected,
         )
 

--- a/src/app.py
+++ b/src/app.py
@@ -30,6 +30,7 @@ if __package__ and __package__ != "__main__":
     from .leaderboard import leaderboard_table_data
     from .revenue_trend import revenue_trend_chart_ui
     from .map_chart import country_choropleth_ui
+    from .kpi_calculations import compute_yoy_revenue, compute_mom_revenue
 else:
     from theme import get_head_content
     from constants import COUNTRY_CODES, WORLD_TOPO_URL
@@ -38,6 +39,7 @@ else:
     from leaderboard import leaderboard_table_data
     from revenue_trend import revenue_trend_chart_ui
     from map_chart import country_choropleth_ui
+    from kpi_calculations import compute_yoy_revenue, compute_mom_revenue
 
 # -- Load data via DuckDB (lazy) -----------------------------------------------
 con = ibis.duckdb.connect()
@@ -135,44 +137,11 @@ def server(input, output, session):
 
     @render.text
     def yoy_revenue():
-        # Compare the last available year's revenue (up to its last month)
-        # to the same months in the prior year. Responds to country/product filters.
-        data = non_date_filtered_data()
-        if data.empty:
-            return "N/A"
-        monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum()
-        last_date = data["Date"].max()
-        current_year = last_date.year
-        last_month = last_date.month
-        current_rev = monthly[
-            (monthly.index.year == current_year) & (monthly.index.month <= last_month)
-        ].sum()
-        prior_rev = monthly[
-            (monthly.index.year == current_year - 1) & (monthly.index.month <= last_month)
-        ].sum()
-        if prior_rev == 0:
-            return "N/A"
-        pct = (current_rev - prior_rev) / prior_rev * 100
-        arrow = "+" if pct >= 0 else ""
-        return f"{arrow}{pct:.1f}%"
+        return compute_yoy_revenue(non_date_filtered_data())
 
     @render.text
     def mom_revenue():
-        # Compare the last available month's revenue to the prior month.
-        # Responds to country/product filters.
-        data = non_date_filtered_data()
-        if data.empty:
-            return "N/A"
-        monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum().sort_index()
-        if len(monthly) < 2:
-            return "N/A"
-        current_rev = monthly.iloc[-1]
-        prior_rev = monthly.iloc[-2]
-        if prior_rev == 0:
-            return "N/A"
-        pct = (current_rev - prior_rev) / prior_rev * 100
-        arrow = "+" if pct >= 0 else ""
-        return f"{arrow}{pct:.1f}%"
+        return compute_mom_revenue(non_date_filtered_data())
 
     @render.ui
     def map_chart():

--- a/src/app.py
+++ b/src/app.py
@@ -90,6 +90,20 @@ def server(input, output, session):
             query = query.filter(t["Product"].isin(input.country()))
         return query.to_pandas()
 
+    @reactive.calc
+    def map_data():
+        """Date- and product-filtered data for the map, without country filter.
+        Keeps all countries visible and clickable regardless of the country selection.
+        """
+        query = t
+        start, end = input.date_range()
+        query = query.filter(
+            (t["Date"] >= str(start)) & (t["Date"] <= str(end))
+        )
+        if input.product():
+            query = query.filter(t["Product"].isin(input.product()))
+        return query.to_pandas()
+
     @render.text
     def total_revenue():
         return f"${filtered_data()['Amount'].sum():,.0f}"
@@ -162,9 +176,24 @@ def server(input, output, session):
 
     @render.ui
     def map_chart():
+        selected = list(input.country()) if input.country() else None
         return country_choropleth_ui(
-            filtered_data(), COUNTRY_CODES, WORLD_TOPO_URL, 320, "350px"
+            map_data(), COUNTRY_CODES, WORLD_TOPO_URL, 320, "350px",
+            clickable=True, selected_countries=selected,
         )
+
+    @reactive.effect
+    def _on_map_country_click():
+        country = input.map_clicked_country()
+        if not country:
+            return
+        with reactive.isolate():
+            current = list(input.country()) if input.country() else []
+        if country in current:
+            updated = [c for c in current if c != country]
+        else:
+            updated = current + [country]
+        ui.update_selectize("country", selected=updated)
 
     @render.data_frame
     def leaderboard_table():

--- a/src/kpi_calculations.py
+++ b/src/kpi_calculations.py
@@ -1,0 +1,51 @@
+"""KPI metric calculations: year-over-year and month-over-month revenue change.
+
+Extracted from the Shiny server function so they can be tested in isolation.
+"""
+
+import pandas as pd
+
+
+def compute_yoy_revenue(data: pd.DataFrame) -> str:
+    """Compute year-over-year revenue change for the most recent year vs the prior year.
+
+    Compares revenue for the current year (up to its last available month) against
+    the same months in the prior year. Returns a formatted percentage string or 'N/A'.
+    """
+    if data.empty:
+        return "N/A"
+    monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum()
+    last_date = data["Date"].max()
+    current_year = last_date.year
+    last_month = last_date.month
+    current_rev = monthly[
+        (monthly.index.year == current_year) & (monthly.index.month <= last_month)
+    ].sum()
+    prior_rev = monthly[
+        (monthly.index.year == current_year - 1) & (monthly.index.month <= last_month)
+    ].sum()
+    if prior_rev == 0:
+        return "N/A"
+    pct = (current_rev - prior_rev) / prior_rev * 100
+    arrow = "+" if pct >= 0 else ""
+    return f"{arrow}{pct:.1f}%"
+
+
+def compute_mom_revenue(data: pd.DataFrame) -> str:
+    """Compute month-over-month revenue change for the two most recent months.
+
+    Compares the last available month's revenue to the prior month's revenue.
+    Returns a formatted percentage string or 'N/A'.
+    """
+    if data.empty:
+        return "N/A"
+    monthly = data.groupby(data["Date"].dt.to_period("M"))["Amount"].sum().sort_index()
+    if len(monthly) < 2:
+        return "N/A"
+    current_rev = monthly.iloc[-1]
+    prior_rev = monthly.iloc[-2]
+    if prior_rev == 0:
+        return "N/A"
+    pct = (current_rev - prior_rev) / prior_rev * 100
+    arrow = "+" if pct >= 0 else ""
+    return f"{arrow}{pct:.1f}%"

--- a/src/map_chart.py
+++ b/src/map_chart.py
@@ -4,11 +4,39 @@ import pandas as pd
 import altair as alt
 from shiny import ui
 
+# JS injected into the map iframe to forward country clicks to the parent Shiny app
+_MAP_CLICK_JS = """\
+  <script>
+    (function() {
+      var _orig = window.vegaEmbed;
+      window.vegaEmbed = function(el, spec, opt) {
+        return _orig(el, spec, opt).then(function(result) {
+          result.view.addEventListener('click', function(event, item) {
+            if (item && item.datum && item.datum['Country']) {
+              window.parent.postMessage(
+                {type: 'cocoa_map_click', country: item.datum['Country']}, '*'
+              );
+            }
+          });
+          return result;
+        });
+      };
+    })();
+  </script>
+"""
+
+_IIFE_MARKER = "  <script>\n    (function(vegaEmbed) {"
+
+
+def _inject_click_handler(html: str) -> str:
+    """Patch vegaEmbed in chart HTML to send clicked country name to parent via postMessage."""
+    return html.replace(_IIFE_MARKER, _MAP_CLICK_JS + _IIFE_MARKER, 1)
+
 
 def map_chart_ui():
     """Build the world map card."""
     return ui.card(
-        ui.card_header("Sales by Country"),
+        ui.card_header("Sales by Country (click to filter)"),
         ui.output_ui("map_chart"),
         full_screen=True,
     )
@@ -20,6 +48,8 @@ def country_choropleth_ui(
     world_topo_url: str,
     chart_height: int = 320,
     iframe_height: str = "350px",
+    clickable: bool = False,
+    selected_countries: list | None = None,
 ):
     """
     Build a country revenue choropleth UI from transaction data.
@@ -36,19 +66,22 @@ def country_choropleth_ui(
     topo = alt.topo_feature(world_topo_url, "countries")
     background = (
         alt.Chart(topo)
-        .mark_geoshape(fill="#d3c4b4", stroke="white", strokeWidth=0.5)
+        .mark_geoshape(fill="#8C8C8C", stroke="white", strokeWidth=0.5)
         .project("naturalEarth1")
         .properties(width="container", height=chart_height)
+    )
+    min_amount = float(country_sales["Amount"].min())
+    max_amount = float(country_sales["Amount"].max())
+    fixed_color = alt.Color(
+        "Amount:Q",
+        scale=alt.Scale(scheme="oranges", domain=[min_amount, max_amount]),
+        legend=alt.Legend(title="Revenue (USD)"),
     )
     sales_layer = (
         alt.Chart(topo)
         .mark_geoshape(stroke="white", strokeWidth=0.5)
         .encode(
-            color=alt.Color(
-                "Amount:Q",
-                scale=alt.Scale(scheme="oranges"),
-                legend=alt.Legend(title="Revenue (USD)"),
-            ),
+            color=fixed_color,
             tooltip=[
                 alt.Tooltip("Country:N", title="Country"),
                 alt.Tooltip("Amount:Q", format="$,.0f", title="Revenue"),
@@ -61,8 +94,47 @@ def country_choropleth_ui(
         .project("naturalEarth1")
         .properties(width="container", height=chart_height)
     )
-    chart = (background + sales_layer).configure_view(strokeWidth=0)
+    if selected_countries:
+        selected_sales = country_sales[country_sales["Country"].isin(selected_countries)]
+
+        # All data countries in dark grey (unselected state)
+        dimmed_layer = (
+            alt.Chart(topo)
+            .mark_geoshape(fill="#8C8C8C", stroke="white", strokeWidth=0.5)
+            .transform_lookup(
+                lookup="id",
+                from_=alt.LookupData(country_sales, "id", ["Amount", "Country"]),
+            )
+            .project("naturalEarth1")
+            .properties(width="container", height=chart_height)
+        )
+        # Only selected countries in orange on top, using the same fixed scale
+        selected_layer = (
+            alt.Chart(topo)
+            .mark_geoshape(stroke="white", strokeWidth=0.5)
+            .encode(
+                color=fixed_color,
+                tooltip=[
+                    alt.Tooltip("Country:N", title="Country"),
+                    alt.Tooltip("Amount:Q", format="$,.0f", title="Revenue"),
+                ],
+            )
+            .transform_lookup(
+                lookup="id",
+                from_=alt.LookupData(selected_sales, "id", ["Amount", "Country"]),
+            )
+            .project("naturalEarth1")
+            .properties(width="container", height=chart_height)
+        )
+        layers = [background, dimmed_layer, selected_layer]
+    else:
+        layers = [background, sales_layer]
+
+    chart = alt.layer(*layers).configure_view(strokeWidth=0)
+    html = chart.to_html()
+    if clickable:
+        html = _inject_click_handler(html)
     return ui.tags.iframe(
-        srcdoc=chart.to_html(),
+        srcdoc=html,
         style=f"width:100%;height:{iframe_height};border:none;",
     )

--- a/src/revenue_trend.py
+++ b/src/revenue_trend.py
@@ -44,7 +44,7 @@ def revenue_trend_chart_ui(data: pd.DataFrame):
                 "Sales Person:N",
                 title="Sales Rep",
                 scale=alt.Scale(
-                    range=["#5D3A1A", "#8B5E3C", "#C4A35A", "#A0522D", "#D2956A"]
+                    range=["#E63946", "#1D8CD6", "#2ECC71", "#9B59B6", "#F39C12"]
                 ),
             ),
             tooltip=[

--- a/src/theme.py
+++ b/src/theme.py
@@ -92,12 +92,22 @@ h1, h2, h3, h4, .card-header {
 """
 
 
+_MAP_CLICK_LISTENER_JS = """
+window.addEventListener('message', function(event) {
+    if (event.data && event.data.type === 'cocoa_map_click') {
+        Shiny.setInputValue('map_clicked_country', event.data.country, {priority: 'event'});
+    }
+});
+"""
+
+
 def get_head_content():
-    """Return head content: Bootstrap Icons and chocolate theme CSS."""
+    """Return head content: Bootstrap Icons, chocolate theme CSS, and map click listener."""
     return head_content(
         ui.tags.link(
             rel="stylesheet",
             href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.11.3/font/bootstrap-icons.min.css",
         ),
         ui.tags.style(CHOCOLATE_CSS),
+        ui.tags.script(_MAP_CLICK_LISTENER_JS),
     )

--- a/src/theme.py
+++ b/src/theme.py
@@ -59,9 +59,8 @@ h1, h2, h3, h4, .card-header {
   border-color: var(--chocolate-medium) !important;
   box-shadow: 0 0 0 0.2rem rgba(93, 58, 26, 0.2) !important;
 }
-/* Auto height based on widget content */
+/* Auto height based on widget content (value boxes and standalone cards only) */
 .bslib-card, .card {
-  height: auto !important;
   min-height: 0 !important;
 }
 .bslib-value-box {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,69 @@
+"""Shared pytest fixtures for CocoaBoard tests."""
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_df():
+    """Small in-memory DataFrame with two reps across two months for leaderboard tests.
+
+    Alice totals $5,000 and Bob totals $1,500 (total $6,500).
+    """
+    return pd.DataFrame(
+        {
+            "Sales Person": ["Alice", "Alice", "Bob", "Bob"],
+            "Country": ["Australia", "Australia", "UK", "India"],
+            "Product": ["Dark Bars", "Milk Bars", "Dark Bars", "Dark Bars"],
+            "Date": pd.to_datetime(
+                ["2022-01-15", "2022-02-10", "2022-01-20", "2022-02-25"]
+            ),
+            "Amount": [3000.0, 2000.0, 1000.0, 500.0],
+            "Boxes Shipped": [300, 200, 100, 50],
+        }
+    )
+
+
+@pytest.fixture
+def empty_df():
+    """Empty DataFrame with the correct column schema for edge-case tests."""
+    return pd.DataFrame(
+        columns=["Sales Person", "Country", "Product", "Date", "Amount", "Boxes Shipped"]
+    )
+
+
+@pytest.fixture
+def two_year_df():
+    """DataFrame spanning two years (2022–2023) for YoY and MoM calculation tests.
+
+    Monthly totals: Jan-2022=100, Feb-2022=200, Jan-2023=200, Feb-2023=400.
+    Expected YoY: +100.0% (prior 300 → current 600).
+    Expected MoM: +100.0% (Jan-2023 200 → Feb-2023 400).
+    """
+    return pd.DataFrame(
+        {
+            "Sales Person": ["Alice"] * 4,
+            "Country": ["Australia"] * 4,
+            "Product": ["Dark Bars"] * 4,
+            "Date": pd.to_datetime(
+                ["2022-01-15", "2022-02-20", "2023-01-15", "2023-02-20"]
+            ),
+            "Amount": [100.0, 200.0, 200.0, 400.0],
+            "Boxes Shipped": [10, 20, 20, 40],
+        }
+    )
+
+
+@pytest.fixture
+def single_month_df():
+    """DataFrame with only one month of data for the MoM edge-case test."""
+    return pd.DataFrame(
+        {
+            "Sales Person": ["Alice", "Alice"],
+            "Country": ["Australia", "Australia"],
+            "Product": ["Dark Bars", "Milk Bars"],
+            "Date": pd.to_datetime(["2022-01-10", "2022-01-25"]),
+            "Amount": [500.0, 300.0],
+            "Boxes Shipped": [50, 30],
+        }
+    )

--- a/tests/test_playwright.py
+++ b/tests/test_playwright.py
@@ -1,0 +1,67 @@
+"""Playwright browser tests for CocoaBoard dashboard.
+
+These tests verify end-to-end behavior by launching the real Shiny app and
+interacting with it through a headless browser.
+
+Prerequisites (one-time):
+    playwright install chromium
+
+Run with:
+    pytest tests/test_playwright.py
+"""
+
+import re
+from pathlib import Path
+
+from playwright.sync_api import Page, expect
+from shiny.pytest import create_app_fixture
+
+_APP_PATH = Path(__file__).parent.parent / "src" / "app.py"
+app = create_app_fixture(_APP_PATH)
+
+_TIMEOUT = 15_000  # ms — generous timeout for Shiny's reactive startup
+
+
+def test_dashboard_renders_all_sections(page: Page, app):
+    """All main dashboard sections (leaderboard, map, KPI boxes) must be visible on
+    load; a missing section indicates a UI component failed to mount or threw an error."""
+    page.goto(app.url)
+    expect(page).to_have_title("CocoaBoard")
+    expect(page.get_by_text("Sales Rep Leaderboard")).to_be_visible(timeout=_TIMEOUT)
+    expect(page.get_by_text("Sales by Country")).to_be_visible()
+
+
+def test_total_revenue_kpi_displays_dollar_amount(page: Page, app):
+    """The total revenue KPI box must render a dollar-formatted value (e.g. '$1,234');
+    a broken reactive pipeline would leave the element empty or show raw numbers."""
+    page.goto(app.url)
+    revenue_el = page.locator("#total_revenue")
+    revenue_el.wait_for(timeout=_TIMEOUT)
+    value = revenue_el.inner_text()
+    assert re.match(r"^\$[\d,]+$", value), f"Expected '$...', got: {value!r}"
+
+
+def test_country_filter_keeps_leaderboard_visible(page: Page, app):
+    """Applying a country filter must update the leaderboard without crashing;
+    a broken filter reactive would clear the output or raise an unhandled error."""
+    page.goto(app.url)
+    # Wait for the initial leaderboard render
+    page.locator("#leaderboard_table").wait_for(timeout=_TIMEOUT)
+    # Set country filter via Shiny's JS API and wait for reactivity to settle
+    page.evaluate("window.Shiny.setInputValue('country', ['Australia'], {priority: 'event'})")
+    page.wait_for_timeout(2_000)
+    expect(page.locator("#leaderboard_table")).to_be_visible()
+
+
+def test_out_of_range_date_shows_no_data_message(page: Page, app):
+    """A date range entirely outside the dataset must show 'No data to display.'
+    for each chart component; the empty-state guard prevents unhandled exceptions."""
+    page.goto(app.url)
+    page.locator("#leaderboard_table").wait_for(timeout=_TIMEOUT)
+    # Push a future date range that has no matching rows
+    page.evaluate(
+        "window.Shiny.setInputValue('date_range', ['2030-01-01', '2030-12-31'], {priority: 'event'})"
+    )
+    page.wait_for_timeout(3_000)
+    # At least one "No data to display." message should appear (map or trend chart)
+    expect(page.get_by_text("No data to display.").first).to_be_visible(timeout=8_000)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,135 @@
+"""Unit tests for CocoaBoard pure data-transformation functions.
+
+These tests verify isolated function behavior with explicit inputs and expected outputs.
+Run with: pytest tests/test_unit.py
+"""
+
+import pandas as pd
+import pytest
+
+from src.leaderboard import leaderboard_table_data
+from src.map_chart import _inject_click_handler, _IIFE_MARKER, _MAP_CLICK_JS
+from src.kpi_calculations import compute_yoy_revenue, compute_mom_revenue
+
+
+# ── leaderboard_table_data ────────────────────────────────────────────────────
+
+
+def test_leaderboard_empty_returns_correct_schema(empty_df):
+    """Empty input yields a DataFrame with all expected column headers; any schema
+    change would break downstream rendering in the Shiny DataGrid component."""
+    result = leaderboard_table_data(empty_df)
+    expected_cols = ["Rank", "Sales Rep", "Revenue", "Transactions", "Boxes", "Avg Deal", "Rev Share"]
+    assert list(result.columns) == expected_cols
+    assert len(result) == 0
+
+
+def test_leaderboard_ranks_by_revenue_descending(sample_df):
+    """Reps are sorted by total revenue descending so the top earner is always rank 1;
+    a sort-direction bug would silently flip the leaderboard."""
+    result = leaderboard_table_data(sample_df)
+    reps = result.iloc[:-1]  # exclude summary row
+    assert reps.iloc[0]["Sales Rep"] == "Alice"   # Alice: $5,000
+    assert reps.iloc[1]["Sales Rep"] == "Bob"     # Bob:   $1,500
+    assert list(reps["Rank"]) == [1, 2]
+
+
+def test_leaderboard_summary_row_shows_totals(sample_df):
+    """The final row must aggregate all reps into a 'AVERAGE / TOTAL' summary;
+    a missing summary row would break the leaderboard footer display."""
+    result = leaderboard_table_data(sample_df)
+    summary = result.iloc[-1]
+    assert summary["Sales Rep"] == "AVERAGE / TOTAL"
+    assert summary["Revenue"] == "$6,500"
+    assert summary["Rev Share"] == "100.0%"
+
+
+def test_leaderboard_rev_shares_sum_to_100(sample_df):
+    """Individual rev shares must sum to 100 % so the footer is consistent;
+    a rounding or division error could cause shares to drift above or below 100."""
+    result = leaderboard_table_data(sample_df)
+    reps = result.iloc[:-1]  # exclude summary
+    total = sum(float(r.strip("%")) for r in reps["Rev Share"])
+    assert abs(total - 100.0) < 0.2  # allow ±0.2 for display rounding
+
+
+# ── _inject_click_handler ─────────────────────────────────────────────────────
+
+
+def test_inject_click_handler_inserts_js_block():
+    """The click-handler injection must insert the postMessage JS before the Vega IIFE;
+    without it, map clicks cannot propagate country names to the Shiny server."""
+    html = f"<head></head><body>{_IIFE_MARKER}</body>"
+    result = _inject_click_handler(html)
+    assert _MAP_CLICK_JS in result
+
+
+def test_inject_click_handler_preserves_iife_marker():
+    """The IIFE marker must remain in the output after injection so Vega still
+    renders the chart; losing the marker would produce broken chart HTML."""
+    html = f"<head></head><body>{_IIFE_MARKER}</body>"
+    result = _inject_click_handler(html)
+    assert _IIFE_MARKER in result
+
+
+def test_inject_click_handler_noop_on_missing_marker():
+    """HTML that does not contain the IIFE marker must pass through unchanged;
+    mis-injecting into arbitrary HTML would corrupt unrelated markup."""
+    html = "<html><body>no marker here</body></html>"
+    result = _inject_click_handler(html)
+    assert result == html
+
+
+# ── compute_yoy_revenue ───────────────────────────────────────────────────────
+
+
+def test_compute_yoy_revenue_empty_returns_na(empty_df):
+    """Empty data must return 'N/A' instead of raising a ZeroDivisionError;
+    this guards the KPI box when all active filters produce no rows."""
+    assert compute_yoy_revenue(empty_df) == "N/A"
+
+
+def test_compute_yoy_revenue_positive_growth(two_year_df):
+    """YoY returns '+100.0%' when revenue exactly doubles year-over-year;
+    an incorrect formula (e.g. swapped numerator/denominator) would flip the sign."""
+    # 2022 Jan–Feb: 100+200=300; 2023 Jan–Feb: 200+400=600 → (600-300)/300*100 = +100.0%
+    assert compute_yoy_revenue(two_year_df) == "+100.0%"
+
+
+def test_compute_yoy_revenue_single_year_returns_na():
+    """When only one calendar year of data is present, prior_rev is 0 and the function
+    must return 'N/A' rather than divide by zero."""
+    df = pd.DataFrame(
+        {
+            "Sales Person": ["Alice"],
+            "Country": ["Australia"],
+            "Product": ["Dark Bars"],
+            "Date": pd.to_datetime(["2022-06-15"]),
+            "Amount": [1000.0],
+            "Boxes Shipped": [100],
+        }
+    )
+    assert compute_yoy_revenue(df) == "N/A"
+
+
+# ── compute_mom_revenue ───────────────────────────────────────────────────────
+
+
+def test_compute_mom_revenue_empty_returns_na(empty_df):
+    """Empty data must return 'N/A' without raising an exception;
+    guards the MoM KPI box when all filters produce no matching rows."""
+    assert compute_mom_revenue(empty_df) == "N/A"
+
+
+def test_compute_mom_revenue_single_month_returns_na(single_month_df):
+    """With only one month of data there is no prior month to compare, so the function
+    must return 'N/A'; otherwise the MoM box would show a spurious percentage."""
+    assert compute_mom_revenue(single_month_df) == "N/A"
+
+
+def test_compute_mom_revenue_positive_growth(two_year_df):
+    """MoM returns '+100.0%' when the last month's revenue doubles the prior month's;
+    incorrect indexing (e.g. comparing wrong months) would return a wrong value."""
+    # Monthly sorted: Jan-2022=100, Feb-2022=200, Jan-2023=200, Feb-2023=400
+    # Current=Feb-2023=400, Prior=Jan-2023=200 → (400-200)/200*100 = +100.0%
+    assert compute_mom_revenue(two_year_df) == "+100.0%"


### PR DESCRIPTION
## Summary

- **Map click-to-filter**: Clicking a country on the choropleth map now toggles it in the country selectize filter, enabling direct chart-to-filter interaction via postMessage JS injection
- **Candy-themed chart palette**: Revenue trend line chart uses a colorful candy-inspired color palette (`#E63946`, `#1D8CD6`, `#2ECC71`, `#9B59B6`, `#F39C12`) for better visual identity
- **Map/leaderboard height alignment**: Fixed card height override so the map and leaderboard cards render at the same height
## Issues addressed

Closes #61, #62, #64, #65, #66

