### PR TITLE
Fix monthly x-axis on trend chart and improve map legend

### DIFF
--- a/src/map_chart.py
+++ b/src/map_chart.py
@@ -71,12 +71,14 @@ def country_choropleth_ui(
         .project("naturalEarth1")
         .properties(width="container", height=chart_height)
     )
-    min_amount = float(country_sales["Amount"].min())
     max_amount = float(country_sales["Amount"].max())
     fixed_color = alt.Color(
         "Amount:Q",
-        scale=alt.Scale(scheme="oranges", domain=[min_amount, max_amount]),
-        legend=alt.Legend(title="Revenue (USD)"),
+        scale=alt.Scale(scheme="oranges", domain=[0, max_amount]),
+        legend=alt.Legend(
+            title="Revenue (USD)",
+            labelExpr="'$' + format(datum.value / 1000, ',.0f') + 'K'",
+        ),
     )
     sales_layer = (
         alt.Chart(topo)

--- a/src/revenue_trend.py
+++ b/src/revenue_trend.py
@@ -39,7 +39,12 @@ def revenue_trend_chart_ui(data: pd.DataFrame):
         alt.Chart(monthly)
         .mark_line(point=True)
         .encode(
-            x=alt.X("Month:T", title="Month"),
+            x=alt.X(
+                "Month:T",
+                title="Month",
+                timeUnit="yearmonth",
+                axis=alt.Axis(tickCount="month", format="%b %Y", labelAngle=-45),
+            ),
             y=alt.Y("Amount:Q", title="Revenue (USD)", axis=alt.Axis(format="$,.0f")),
             color=alt.Color(
                 "Sales Person:N",


### PR DESCRIPTION
## Summary
- **#77**: Forces `yearmonth` time unit and monthly tick intervals on the revenue trend chart x-axis so it always displays by month regardless of date range
- **#89**: Starts the map color scale at 0 (instead of the data minimum) so country performance is visually comparable; legend labels now formatted in thousands (e.g. `$1,100K`)

